### PR TITLE
Conform bower.json main property to specification

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,13 @@
     "brand-color",
     "branding"
   ],
-  "main": "/dist/",
+  "main": [
+    "dist/latest/css/brand-colors.latest.css",
+    "dist/latest/less/brand-colors.latest.less",
+    "dist/latest/sass/brand-colors.latest.sass",
+    "dist/latest/scss/brand-colors.latest.scss",
+    "dist/latest/stylus/brand-colors.latest.styl"
+  ],
   "ignore": [
   "node-modules/**",
   "CNAME"


### PR DESCRIPTION
Main is supposed to be the various entry point files files for a package. Other packages then figure out what to do with the entry points as needed.

I currently use this with wiredep, which allows for [Bower overrides](https://github.com/taptapship/wiredep#bower-overrides), but obviously it's better to rely on the package maintainer(s) to specify the entry-points for their package. This PR does exactly that.

See: https://github.com/bower/spec/blob/master/json.md#main