### PR TITLE
Added new method to get colors grouped by brand name

### DIFF
--- a/data/brandColors.js
+++ b/data/brandColors.js
@@ -814,7 +814,7 @@ var _brandColors = {
   'sap': '#003366',
   'sap-2': '#999999',
   'scratch': '#F7A83A',
-  'scratch': '#25AFF4',
+  'scratch-1': '#25AFF4',
   'scribd': '#1a7bba',
   'shazam': '#0088ff',
   'shazam-10': '#949494',
@@ -1089,7 +1089,7 @@ var _brandColors = {
   'wordpress-2': '#d54e21',
   'wordpress-3': '#464646',
   'wordpress-com': '#0087be',
-  'wordpress-com': '#1e8cbe',
+  'wordpress-com-1': '#1e8cbe',
   'wordpress-com-10': '#668eaa',
   'wordpress-com-11': '#4f748e',
   'wordpress-com-12': '#3d596d',
@@ -1158,11 +1158,11 @@ var _brandColors = {
   'zopim': '#ff9d3b'
 };
 
-var _groupedColors = [];
+var _groupedColors = {};
 
 var brandColors = Object.keys(_brandColors).map(function(key) {
   var formatted = key.replace(/-([0-9]+)/g, '');
-  
+
   if (typeof _groupedColors[formatted] == "undefined")
     _groupedColors[formatted] = [];
   _groupedColors[formatted].push(_brandColors[key]);

--- a/data/brandColors.js
+++ b/data/brandColors.js
@@ -1158,19 +1158,35 @@ var _brandColors = {
   'zopim': '#ff9d3b'
 };
 
-var brandColors = Object.keys(_brandColors).map(function(key){
-  return {name: key, color: _brandColors[key]}
+var _groupedColors = [];
+
+var brandColors = Object.keys(_brandColors).map(function(key) {
+  var formatted = key.replace(/-([0-9]+)/g, '');
+  
+  if (typeof _groupedColors[formatted] == "undefined")
+    _groupedColors[formatted] = [];
+  _groupedColors[formatted].push(_brandColors[key]);
+
+  return {
+    name: key,
+    color: _brandColors[key]
+  }
 });
 
 function getAll() {
   return brandColors;
 }
 
+function getByGroup() {
+  return _groupedColors;
+}
+
 function find(name) {
-  return brandColors.filter(function(brand){
+  return brandColors.filter(function(brand) {
     return brand.name === name;
   });
 }
 
 exports.getAll = getAll;
+exports.getByGroup = getByGroup;
 exports.find = find;

--- a/data/brandColors.js
+++ b/data/brandColors.js
@@ -1177,8 +1177,16 @@ function getAll() {
   return brandColors;
 }
 
-function getByGroup() {
-  return _groupedColors;
+function getByGroup(brandName) {
+  if(!brandName) return _groupedColors;
+  else if(typeof brandName=='object'){
+    var collection={};
+    for(var i=0;i<brandName.length;i++){
+      collection[brandName[i]]=getByGroup(brandName[i]); 
+    }
+    return collection;
+  }
+  return _groupedColors[brandName];
 }
 
 function find(name) {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,2 @@
+var c=require('./data/brandColors.js');
+console.log(c.getByGroup(['zapier','facebook','youtube','xing']));


### PR DESCRIPTION
Removed digits at the end of the brand names and grouped colors under
common brand name.

```javascript
getByGroup() // returns

{
  blackberry: ['#005387','#8cb811','#fdb813','#88aca1','#000000','#788cb6','#a1a1a4','#8f8f8c'],
  blogger: ['#f57d00'],
  boeing: ['#0033a1'],
  bombardier: ['#8996a0'],
  booking-com: ['#003580'],
  bower: ['#ffcc2f', '#ef5734', '#00acee', '#2baf2b', '#543729', '#cecece'],
  boy-scouts-of-america: ['#ce1126', '#003f87'],
  british-airways: ['#075aaa','#eb2226','#01295c','#efe9e5','#aca095','#b9cfed','#a7a9ac'],
  bt: ['#d52685', '#553a99', '#6cbc35', '#fd9f3e', '#08538c'],
  buffer: ['#168eea','#ee4f4f','#fff9ea','#76b852','#323b43','#59626a','#ced7df','#eff3f6','#f4f7f9'],
  burger-king: ['#ec1c24', '#fdbd10', '#0066b2', '#ed7902'],
  ...
}

```

```javascript
// get specific brand colors
getByGroup()['blackberry']; //or
getByGroup().blackberry;
```